### PR TITLE
Fix Function.bind in Safari in case the original function had an undefined prototype.

### DIFF
--- a/lib/augment.function.bind.js
+++ b/lib/augment.function.bind.js
@@ -7,7 +7,7 @@ if ( !Function.prototype.bind ) {
         self = this, 
         nop = function () {}, 
         bound = function () {
-          return self.apply( this instanceof nop ? this : ( obj || {} ), 
+          return self.apply( nop.prototype && this instanceof nop ? this : ( obj || {} ), 
                               args.concat( slice.call(arguments) ) );    
         };
 


### PR DESCRIPTION
Example: call = Function.prototype.call.bind(something)
In Safari, native functions don't seem to have the prototype. The subsequent use of instanceof on a function with an undefined prototype causes Safari to throw an error.
