### PR TITLE
update docs link to correct gh-pages url

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ It combines the code snippets supplied by [Mozilla](https://developer.mozilla.or
 
 ## Docs
 
-For documentation and usage see the [Augment.js](http://augmentjs.com) docs site.
+For documentation and usage see the [Augment.js](http://olivernn.github.com/augment.js) docs site.
 
 ## Build
 


### PR DESCRIPTION
Fixes #16

With your [lunr-js](http://lunrjs.com/) project being mentioned in the gh's latest [blog post](https://github.com/blog/1939-how-github-uses-github-to-document-github) and increased traffic I'm guessing plenty more people will be finding their way here (like me!). So to be helpful, this will just revert the docs link back to http://olivernn.github.com/augment.js. Probably should update the website link at the top of the repo too.

Hope it helps!