### PR TITLE
Fix Augment.js docs url

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ It combines the code snippets supplied by [Mozilla](https://developer.mozilla.or
 
 ## Docs
 
-For documentation and usage see the [Augment.js](http://olivernn.github.com/augment.js) docs site.
+For documentation and usage see the [Augment.js](https://olivernn.github.io/augment.js) docs site.
 
 ## Build
 


### PR DESCRIPTION
Just a small change to fix the doc page URL. Current one is broken.